### PR TITLE
Fix relationship with model changes

### DIFF
--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -1,0 +1,119 @@
+# Relationships
+
+Foundry supports many-to-many relationships between any two Models (or with WordPress core objects).
+
+
+## Declaring relationships
+
+Models can declare support for relationships by using the `Foundry\Database\Relations\WithRelationships` trait.
+
+WithRelationships requires defining a `get_relationships()` method, which is used to define the model's relationships. This method should return an associative array, with the keys as the relationship ID, and values as an associative array with options.
+
+All relationship types share the following common options:
+
+* `type` (string) - The type of the relationship: `has_many`, `belongs_to`, `has_one`
+* `model` (string) - Class name for the model
+
+Note: the ID you chose may be stored in the database, and is not automatically migrated if you change it, so select it carefully.
+
+```php
+use Foundry\Database\Model;
+use Foundry\Database\Relations\WithRelationships;
+
+class MyModel extends Model {
+	use WithRelationships;
+
+	public static function get_relationships() : array {
+		return [
+			'other' => [
+				'type' => 'has_many',
+				'model' => OtherModel::class,
+			]
+		]
+	}
+}
+```
+
+### Relationships with WordPress core objects
+
+In many cases, you'll want to relate models to one of the four WordPress core objects: posts, comments, terms, or users.
+
+Since WordPress manages the models for these objects rather than Foundry, they aren't immediately available as regular models. Instead, Foundry implements a `Foundry\Builtin` shim model to allow them to be used for relationships. These shim models can't be used for regular model manipulation, and are only designed for use in relationships.
+
+You can use these built-ins directly in your `get_relationships()` declaration in place of a regular model:
+
+```php
+use Foundry\Builtin\Term;
+use Foundry\Database\Model;
+use Foundry\Database\Relations\WithRelationships;
+
+class MyModel extends Model {
+	use WithRelationships;
+
+	public static function get_relationships() : array {
+		return [
+			'tag' => [
+				'type' => 'has_many',
+				'model' => Term::class,
+			]
+		]
+	}
+}
+```
+
+
+## Relationship types
+
+### Belongs-to relationships
+
+Belongs-to relationships are used for models which belong to a different model, such as the child in a parent-child relationship.
+
+**Note:** Not yet implemented.
+
+### Has-one relationships
+
+Has-one relationships are used for models which have a single other model belonging to them, such as the parent in a parent-child relationship.
+
+**Note:** Not yet implemented.
+
+### Has-many relationships
+
+Has-many relationships are used for models which have zero-or-more other models belonging to them.
+
+The `type` should be set to `has_many` for these relationships. There are no other options.
+
+
+## Using relations
+
+The WithRelationships trait provides the `->get_relation( $id )` helper to use each relation you declare.
+
+
+### Has-many
+
+`$this->get_relation( $id )->get_items()` returns the items connected to the current model.
+
+Models can be added via `$this->get_relation( $id )->add( Model $other )` and removed via `$this->get_relation( $id )->remove( Model $other )`
+
+
+### Querying
+
+Models using WithRelationships will automatically gain support for querying by related items, with `::query()` using the `Foundry\Database\RelationalQuery` builder.
+
+This query builder works just like regular querying, but supports querying by related items:
+
+```
+MyModel::query( [
+	'relationships' => [
+		// Either pass the ID:
+		'rel1' => 42,
+
+		// Or a model instance itself:
+		'rel2' => Other::get( 42 ),
+	],
+
+	// Relation queries can be combined with field queries:
+	'fields' => [
+		'my-value' => 2,
+	],
+])
+```

--- a/inc/builtin/class-term.php
+++ b/inc/builtin/class-term.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Foundry\Builtin;
+
+use Foundry\Database\Model;
+use WP_Error;
+use WP_Term;
+
+class Term extends Model {
+	/**
+	 * Save the pending changes to the database.
+	 *
+	 * @return bool|WP_Error True if saved successfully, false if no changes were made, error otherwise.
+	 */
+	public function save() {
+		return new WP_Error(
+			'foundry.builtin.model.save.cannot_save',
+			'Built-in models cannot be saved'
+		);
+	}
+
+	public function delete() {
+		return new WP_Error(
+			'foundry.builtin.model.delete.cannot_delete',
+			'Built-in models cannot be deleted'
+		);
+	}
+
+	/**
+	 * Convert the model back to the term object.
+	 *
+	 * @return WP_Term
+	 */
+	public function as_term() : WP_Term {
+		return get_term( $this->get_id() );
+	}
+
+	public static function get_table_name() : string {
+		return $GLOBALS['wpdb']->prefix . 'terms';
+	}
+
+	/**
+	 * Convert a term into a model.
+	 *
+	 * @param WP_Term $term
+	 * @return static
+	 */
+	public static function from_term( WP_Term $term ) {
+		$instance = new static( [
+			'term_id' => $term->term_id,
+			'name' => $term->name,
+			'slug' => $term->slug,
+			'term_group' => $term->term_group,
+		] );
+		return $instance;
+	}
+
+	/**
+	 * Get a term model using the term ID.
+	 *
+	 * @param int $id
+	 * @return static|WP_Error
+	 */
+	public static function from_id( int $id ) {
+		$term = get_term( $id );
+		if ( is_wp_error( $term ) ) {
+			return $term;
+		}
+		return static::from_term( $term );
+	}
+
+	public static function get_table_schema() : array {
+		return [
+			'fields' => [
+				'term_id' => 'bigint(20) unsigned NOT NULL auto_increment',
+				'name' => 'varchar(200) NOT NULL default \'\'',
+				'slug' => 'varchar(200) NOT NULL default \'\'',
+				'term_group' => 'bigint(10) NOT NULL default 0',
+			],
+			'indexes' => [
+				'PRIMARY KEY  (term_id)',
+				'KEY slug (slug($max_index_length))',
+				'KEY name (name($max_index_length))',
+			],
+		];
+	}
+
+	public static function ensure_table() {
+		trigger_error( 'Terms table is a core WordPress table and cannot be created.', E_USER_ERROR );
+		exit( 1 );
+	}
+}

--- a/inc/database/class-relationalquery.php
+++ b/inc/database/class-relationalquery.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Foundry\Database;
+
+use WP_Error;
+
+class RelationalQuery extends Query {
+	/**
+	 * @psalm-param TLooseWhereClause $extra_args
+	 *
+	 * @param array $extra_args
+	 * @return string|WP_Error
+	 */
+	protected function build_query() {
+		/** @var \wpdb $wpdb */
+		global $wpdb;
+
+		// If there's no relationship query, just use the parent's method.
+		if ( empty( $this->where['relationships'] ) ) {
+			return parent::build_query();
+		}
+
+		// Remove the "relationships" key from the where clause.
+		$relationships = $this->where['relationships'];
+		$real_where = $this->where;
+		unset( $real_where['relationships'] );
+
+		// Build our regular where query first.
+		$where = $this->build_where( $real_where );
+		if ( is_wp_error( $where ) ) {
+			return $where;
+		}
+
+		list( $where_string, $where_values ) = $where;
+
+		// Now, build the relationship query.
+		$join_where = $this->build_join_where( $relationships );
+		if ( is_wp_error( $join_where ) ) {
+			return $join_where;
+		}
+
+		list( $joins, $join_where_string, $join_where_values ) = $join_where;
+
+		$args = $this->args;
+		$page = $args['page'] ?? 1;
+		$per_page = $args['per_page'] ?? 10;
+
+		$offset = ( $page - 1 ) * $per_page;
+		$limit = $per_page;
+
+		$full_where = '';
+		if ( ! empty( $where_string ) && ! empty( $join_where_string ) ) {
+			$full_where = '( ' . $where_string . ' ) AND ( ' . $join_where_string . ' )';
+		} else {
+			$full_where = $where_string . $join_where_string;
+		}
+		$where_statement = empty( $full_where ) ? '' : 'WHERE ' . $full_where;
+
+		$query = sprintf(
+			'SELECT SQL_CALC_FOUND_ROWS `%1$s`.* FROM `%1$s` %2$s %3$s LIMIT %4$d, %5$d',
+			$this->config['table'],
+			implode( ' ', $joins ),
+			$where_statement,
+			$offset,
+			$limit
+		);
+		$values = array_merge(
+			$where_values,
+			$join_where_values
+		);
+
+		$prepared = empty( $values ) ? $query : $wpdb->prepare( $query, $values );
+		if ( ! $prepared ) {
+			return new WP_Error( 'prepare-failed', 'Preparing values failed.' );
+		}
+		return $prepared;
+	}
+
+	protected function build_join_where( array $args ) {
+		/** @var \wpdb $wpdb */
+		global $wpdb;
+
+		// The full args should be defined per TWhereClause, but we support $args
+		// just being the `fields`, which is an implicit AND relation.
+		if ( ! isset( $args['relation'] ) ) {
+			$args = [
+				'relation' => 'AND',
+				'fields' => $args,
+			];
+		}
+
+		$primary = get_primary_column( $this->config['schema'] );
+		$relationships = $this->config['relationships'];
+		$relation = $args['relation'];
+
+		$added_rel_table = false;
+		$joins = [];
+		$where_string = '';
+		$where_values = [];
+
+		foreach ( $args['fields'] as $key => $query ) {
+			if ( empty( $relationships[ $key ] ) ) {
+				return new WP_Error( 'foundry.database.relationalquery.invalid-relation', 'Invalid relation key: ' . $key );
+			}
+
+			$model = $relationships[ $key ]['model'];
+			switch ( $relationships[ $key ]['type'] ) {
+				case 'has_many':
+					// Has-many relationships are stored in a dedicated table.
+					// Add it once, then reuse the join.
+					$relations_table = $this->config['table'] . '_relationships';
+					if ( ! $added_rel_table ) {
+						$joins[] = sprintf(
+							'LEFT JOIN `%s` ON `%s`.`left_id` = `%s`.`%s`',
+							$relations_table,
+							$relations_table,
+							$this->config['table'],
+							get_primary_column( $this->config['schema'] )
+						);
+						$added_rel_table = true;
+					}
+
+					// Normalize the value, if it's an object.
+					if ( is_object( $query ) ) {
+						$query = $query->get_id();
+					}
+
+					$where = sprintf(
+						'`%1$s`.`relationship` = %2$s AND `%1$s`.`right_id` = %3$d',
+						$relations_table,
+						$key,
+						$query
+					);
+					$where_string .= ' ' . $relation . ' ' . $where;
+					$where_values[] = $query;
+					break;
+				default:
+					return new WP_Error( 'foundry.database.relationalquery.invalid-relation-type', 'Invalid relation type: ' . $relationships[ $key ]['type'] );
+			}
+		}
+
+		$where_string = substr( $where_string, strlen( $relation ) + 1 );
+		if ( $where_string === false ) {
+			//          oWo
+			return [ [], '', [] ];
+		}
+		return [ $joins, $where_string, $where_values ];
+	}
+}

--- a/inc/database/class-relationalquery.php
+++ b/inc/database/class-relationalquery.php
@@ -126,12 +126,13 @@ class RelationalQuery extends Query {
 					}
 
 					$where = sprintf(
-						'`%1$s`.`relationship` = %2$s AND `%1$s`.`right_id` = %3$d',
+						'`%1$s`.`relationship` = %2$s AND `%1$s`.`right_id` = %2$s',
 						$relations_table,
-						$key,
-						$query
+						'%s',
+						'%d'
 					);
 					$where_string .= ' ' . $relation . ' ' . $where;
+					$where_values[] = $key;
 					$where_values[] = $query;
 					break;
 				default:

--- a/inc/database/class-table.php
+++ b/inc/database/class-table.php
@@ -6,7 +6,7 @@ trait Table {
 	/**
 	 * Ensure the table for the model exists.
 	 *
-	 * @return bool|WP_Error True on succes, error otherwise.
+	 * @return bool|WP_Error True on success, error otherwise.
 	 */
 	public static function ensure_table() {
 		$name = static::get_table_name();

--- a/inc/database/namespace.php
+++ b/inc/database/namespace.php
@@ -22,7 +22,12 @@ function ensure_table( string $name, array $schema ) {
 		return create_table( $name, $schema );
 	}
 
-	return conform_table( $name, $schema );
+	$conformed = conform_table( $name, $schema );
+	if ( is_wp_error( $conformed ) ) {
+		return $conformed;
+	}
+
+	return true;
 }
 
 /**

--- a/inc/database/namespace.php
+++ b/inc/database/namespace.php
@@ -11,7 +11,7 @@ use WP_Error;
  *
  * @param string $name
  * @param array $schema
- * @return bool|WP_Error True on succes, error otherwise.
+ * @return bool|WP_Error True on success, error otherwise.
  */
 function ensure_table( string $name, array $schema ) {
 	/** @var \wpdb $wpdb */

--- a/inc/database/relations/class-hasmanyassociation.php
+++ b/inc/database/relations/class-hasmanyassociation.php
@@ -14,16 +14,24 @@ class HasManyAssociation {
 	protected $parent;
 
 	/** @var string */
+	protected $id;
+
+	/** @var string */
 	protected $child_model;
 
-	public function __construct( string $table, Model $parent, string $child_model ) {
+	public function __construct( string $table, Model $parent, string $id, string $child_model ) {
 		$this->table = $table;
 		$this->parent = $parent;
+		$this->id = $id;
 		$this->child_model = $child_model;
 	}
 
 	protected function get_relationship_table_name() : string {
 		return $this->table;
+	}
+
+	protected function get_relationship_id() : string {
+		return $this->id;
 	}
 
 	protected function get_left_model() : string {

--- a/inc/database/relations/class-hasmanyassociation.php
+++ b/inc/database/relations/class-hasmanyassociation.php
@@ -2,7 +2,7 @@
 
 namespace Foundry\Database\Relations;
 
-use Foundry\Database\Idable;
+use Foundry\Database\Model;
 
 class HasManyAssociation {
 	use ManyToMany;
@@ -11,12 +11,12 @@ class HasManyAssociation {
 	protected $table;
 
 	/** @var Model */
-	protected $parent_model;
+	protected $parent;
 
 	/** @var string */
 	protected $child_model;
 
-	public function __construct( string $table, Idable $parent, string $child_model ) {
+	public function __construct( string $table, Model $parent, string $child_model ) {
 		$this->table = $table;
 		$this->parent = $parent;
 		$this->child_model = $child_model;
@@ -38,11 +38,11 @@ class HasManyAssociation {
 		return $this->get_right( $this->parent );
 	}
 
-	public function add( Idable $model ) {
+	public function add( Model $model ) {
 		return $this->create_relation( $this->parent, $model );
 	}
 
-	public function remove( Idable $model ) {
+	public function remove( Model $model ) {
 		return $this->remove_relation( $this->parent, $model );
 	}
 }

--- a/inc/database/relations/class-manytomany.php
+++ b/inc/database/relations/class-manytomany.php
@@ -2,14 +2,14 @@
 
 namespace Foundry\Database\Relations;
 
-use Foundry\Database\Idable;
+use Foundry\Database\Model;
 
 trait ManyToMany {
 	abstract protected function get_relationship_table_name() : string;
 	abstract protected function get_left_model() : string;
 	abstract protected function get_right_model() : string;
 
-	protected function get_left_ids( Idable $right ) : array {
+	protected function get_left_ids( Model $right ) : array {
 		global $wpdb;
 		$right_model = $this->get_right_model();
 		if ( ! ( $right instanceof $right_model ) ) {
@@ -23,14 +23,14 @@ trait ManyToMany {
 		) );
 	}
 
-	protected function get_left( Idable $right ) : array {
+	protected function get_left( Model $right ) : array {
 		$ids = $this->get_left_ids( $right );
 		return array_map( function ( int $id ) {
 			return $this->get_left_model()::get( $id );
 		}, $ids );
 	}
 
-	protected function get_right_ids( Idable $left ) : array {
+	protected function get_right_ids( Model $left ) : array {
 		global $wpdb;
 		$left_model = $this->get_left_model();
 		if ( ! ( $left instanceof $left_model ) ) {
@@ -44,14 +44,14 @@ trait ManyToMany {
 		) );
 	}
 
-	protected function get_right( Idable $left ) : array {
+	protected function get_right( Model $left ) : array {
 		$ids = $this->get_right_ids( $left );
 		return array_map( function ( int $id ) {
 			return $this->get_right_model()::get( $id );
 		}, $ids );
 	}
 
-	protected function create_relation( Idable $left, Idable $right ) {
+	protected function create_relation( Model $left, Model $right ) {
 		global $wpdb;
 		$result = $wpdb->insert(
 			$this->get_relationship_table_name(),
@@ -66,7 +66,7 @@ trait ManyToMany {
 		);
 	}
 
-	protected function remove_relation( Idable $left, Idable $right ) {
+	protected function remove_relation( Model $left, Model $right ) {
 		global $wpdb;
 		$result = $wpdb->delete(
 			$this->get_relationship_table_name(),

--- a/inc/database/relations/class-manytomany.php
+++ b/inc/database/relations/class-manytomany.php
@@ -6,6 +6,7 @@ use Foundry\Database\Model;
 
 trait ManyToMany {
 	abstract protected function get_relationship_table_name() : string;
+	abstract protected function get_relationship_id() : string;
 	abstract protected function get_left_model() : string;
 	abstract protected function get_right_model() : string;
 
@@ -18,7 +19,8 @@ trait ManyToMany {
 
 		$table = $this->get_relationship_table_name();
 		return $wpdb->get_col( $wpdb->prepare(
-			"SELECT `left_id` FROM `$table` WHERE right_id = %d",
+			"SELECT `left_id` FROM `$table` WHERE relationship = %s AND right_id = %d",
+			$this->get_relationship_id(),
 			$right->get_id()
 		) );
 	}
@@ -39,7 +41,8 @@ trait ManyToMany {
 
 		$table = $this->get_relationship_table_name();
 		return $wpdb->get_col( $wpdb->prepare(
-			"SELECT `right_id` FROM `$table` WHERE left_id = %d",
+			"SELECT `right_id` FROM `$table` WHERE relationship = %s AND left_id = %d",
+			$this->get_relationship_id(),
 			$left->get_id()
 		) );
 	}
@@ -56,10 +59,12 @@ trait ManyToMany {
 		$result = $wpdb->insert(
 			$this->get_relationship_table_name(),
 			[
+				'relationship' => $this->get_relationship_id(),
 				'left_id' => $left->get_id(),
 				'right_id' => $right->get_id(),
 			],
 			[
+				'%s',
 				'%d',
 				'%d',
 			]
@@ -71,10 +76,12 @@ trait ManyToMany {
 		$result = $wpdb->delete(
 			$this->get_relationship_table_name(),
 			[
+				'relationship' => $this->get_relationship_id(),
 				'left_id' => $left->get_id(),
 				'right_id' => $right->get_id(),
 			],
 			[
+				'%s',
 				'%d',
 				'%d'
 			]

--- a/inc/database/relations/class-withrelationships.php
+++ b/inc/database/relations/class-withrelationships.php
@@ -79,11 +79,11 @@ trait WithRelationships {
 				return Database\ensure_table( $table_name, $schema );
 
 			case 'belongs_to':
-				// Owned by other model, so not needed here.
+				// Handled by fields or something?
 				return true;
 
 			case 'has_one':
-				// Handled by fields or something?
+				// Owned by other model, so not needed here.
 				return true;
 
 			default:

--- a/inc/database/relations/class-withrelationships.php
+++ b/inc/database/relations/class-withrelationships.php
@@ -3,6 +3,7 @@
 namespace Foundry\Database\Relations;
 
 use Foundry\Database;
+use Foundry\Database\RelationalQuery;
 
 trait WithRelationships {
 	protected $relation_handlers = [];
@@ -56,6 +57,16 @@ trait WithRelationships {
 		}
 
 		return true;
+	}
+
+	public static function query( array $where, array $args = [] ) : Database\Query {
+		$config = [
+			'model' => get_called_class(),
+			'table' => static::get_table_name(),
+			'schema' => static::get_table_schema(),
+			'relationships' => static::get_relationships(),
+		];
+		return new RelationalQuery( $config, $where, $args );
 	}
 
 	protected static function ensure_relationship_table( string $key ) {

--- a/inc/database/relations/class-withrelationships.php
+++ b/inc/database/relations/class-withrelationships.php
@@ -48,7 +48,7 @@ trait WithRelationships {
 			return $res;
 		}
 
-		$res = static::ensure_relationship_table( $key );
+		$res = static::ensure_relationship_table();
 		if ( $res !== true ) {
 			return $res;
 		}
@@ -66,7 +66,7 @@ trait WithRelationships {
 		return new RelationalQuery( $config, $where, $args );
 	}
 
-	protected static function ensure_relationship_table( string $key ) {
+	protected static function ensure_relationship_table() {
 		$created_relationships_table = false;
 		$relationships = static::get_relationships();
 		foreach ( $relationships as $key => $relation ) {

--- a/inc/database/relations/class-withrelationships.php
+++ b/inc/database/relations/class-withrelationships.php
@@ -30,7 +30,7 @@ trait WithRelationships {
 
 		switch ( $relation['type'] ) {
 			case 'has_many':
-				$relationship = new HasManyAssociation( static::get_table_name()  . '_relationships', $this, $relation['model'] );
+				$relationship = new HasManyAssociation( static::get_table_name()  . '_relationships', $this, $type, $relation['model'] );
 				break;
 
 			// case 'has_one':
@@ -66,12 +66,13 @@ trait WithRelationships {
 				$table_name = static::get_table_name()  . '_relationships';
 				$schema = [
 					'fields' => [
+						'relationship' => 'varchar(255) NOT NULL',
 						'left_id' => 'bigint(20) unsigned NOT NULL',
 						'right_id' => 'bigint(20) unsigned NOT NULL',
 					],
 					'indexes' => [
-						'PRIMARY KEY (left_id, right_id)',
-						'KEY (right_id)',
+						'PRIMARY KEY (relationship, left_id, right_id)',
+						'KEY (relationship, right_id)',
 					],
 				];
 


### PR DESCRIPTION
* Switches from the old Idable to Model
* Allows multiple types of relationships with overlapping IDs
* Introduces a new RelationalQuery, which automatically replaces Query for any WithRelationships model
* Adds "builtins" to allow modelling relations between models and core WP objects
* Adds documentation for relationships