### PR TITLE
Add ORDER BY support to Query

### DIFF
--- a/inc/database/class-query.php
+++ b/inc/database/class-query.php
@@ -71,6 +71,13 @@ class Query {
 	protected $where;
 
 	/**
+	 * ORDER BY clauses.
+	 *
+	 * @var array<string, 'ASC'|'DESC'>
+	 */
+	protected $order_by = [];
+
+	/**
 	 * @var bool
 	 */
 	protected $executed = false;
@@ -103,6 +110,49 @@ class Query {
 	 */
 	public function get_args() : array {
 		return $this->args;
+	}
+
+	/**
+	 * Set ORDER BY clauses.
+	 *
+	 * @param array<string, 'ASC'|'DESC'> $order_by Column => direction pairs.
+	 * @return static
+	 */
+	public function order_by( array $order_by ) : self {
+		$this->order_by = $order_by;
+		return $this;
+	}
+
+	/**
+	 * Build the ORDER BY clause.
+	 *
+	 * Only columns defined in the schema are allowed. Invalid columns
+	 * are silently skipped to prevent SQL injection.
+	 *
+	 * @return string SQL ORDER BY clause or empty string.
+	 */
+	protected function build_order_by() : string {
+		if ( empty( $this->order_by ) ) {
+			return '';
+		}
+
+		$fields = $this->config['schema']['fields'];
+		$clauses = [];
+
+		foreach ( $this->order_by as $column => $direction ) {
+			if ( ! isset( $fields[ $column ] ) ) {
+				continue;
+			}
+
+			$direction = strtoupper( $direction ) === 'DESC' ? 'DESC' : 'ASC';
+			$clauses[] = sprintf( '`%s` %s', $column, $direction );
+		}
+
+		if ( empty( $clauses ) ) {
+			return '';
+		}
+
+		return 'ORDER BY ' . implode( ', ', $clauses );
 	}
 
 	protected function repeat_placeholders( array $values ) : string {
@@ -256,10 +306,13 @@ class Query {
 		$offset = ( $page - 1 ) * $per_page;
 		$limit = $per_page;
 
+		$order_by_statement = $this->build_order_by();
+
 		$query = sprintf(
-			'SELECT SQL_CALC_FOUND_ROWS * FROM `%s` %s LIMIT %d, %d',
+			'SELECT SQL_CALC_FOUND_ROWS * FROM `%s` %s %s LIMIT %d, %d',
 			$this->config['table'],
 			$where_statement,
+			$order_by_statement,
 			$offset,
 			$limit
 		);

--- a/inc/database/class-relationalquery.php
+++ b/inc/database/class-relationalquery.php
@@ -56,11 +56,14 @@ class RelationalQuery extends Query {
 		}
 		$where_statement = empty( $full_where ) ? '' : 'WHERE ' . $full_where;
 
+		$order_by_statement = $this->build_order_by();
+
 		$query = sprintf(
-			'SELECT SQL_CALC_FOUND_ROWS `%1$s`.* FROM `%1$s` %2$s %3$s LIMIT %4$d, %5$d',
+			'SELECT SQL_CALC_FOUND_ROWS `%1$s`.* FROM `%1$s` %2$s %3$s %4$s LIMIT %5$d, %6$d',
 			$this->config['table'],
 			implode( ' ', $joins ),
 			$where_statement,
+			$order_by_statement,
 			$offset,
 			$limit
 		);


### PR DESCRIPTION
## Summary

- Adds a fluent `order_by()` method to `Query` for setting ORDER BY clauses after construction
- Adds a `build_order_by()` helper that validates column names against the schema to prevent SQL injection
- Updates `build_query()` in both `Query` and `RelationalQuery` to insert the ORDER BY clause between WHERE and LIMIT

## Usage

```php
Model::query( [ 'status' => 'running' ] )
    ->order_by( [ 'created_at' => 'DESC' ] )
    ->get_results();

// Multiple columns
Model::query( [] )
    ->order_by( [ 'status' => 'ASC', 'created_at' => 'DESC' ] )
    ->get_results();
```

Columns not present in the model's schema are silently skipped. Direction defaults to ASC if an invalid value is passed.

## Test plan

- [ ] `order_by()` returns `$this` for fluent chaining
- [ ] Single column ORDER BY generates correct SQL
- [ ] Multiple columns ORDER BY preserves order
- [ ] Invalid column names are ignored
- [ ] Invalid direction values default to ASC
- [ ] Empty `order_by([])` produces no ORDER BY clause
- [ ] Works with RelationalQuery (JOINs + ORDER BY)
- [ ] No ORDER BY when `order_by()` is not called (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)