### PR TITLE
Fix PHPCS errors

### DIFF
--- a/inc/admin/class-list-table.php
+++ b/inc/admin/class-list-table.php
@@ -2,7 +2,6 @@
 
 namespace Foundry\Admin;
 
-use Foundry\Database\Model;
 use Foundry\Database\Query;
 use WP_List_Table;
 
@@ -37,7 +36,7 @@ abstract class List_Table extends WP_List_Table {
 	 * Data returned from this method is output directly to the browser, and so
 	 * must be escaped by your method (using esc_html() or similar).
 	 *
-	 * @param Model $model Model object.
+	 * @param \Foundry\Database\Model $model Model object.
 	 * @return array|WP_Error Data array on success, or WP_Error object on failure.
 	 */
 	abstract protected function prepare_model_for_output( $model );
@@ -51,7 +50,7 @@ abstract class List_Table extends WP_List_Table {
 	 *
 	 * By default, the item's internal ID is displayed.
 	 *
-	 * @param Model $model Model object.
+	 * @param \Foundry\Database\Model $model Model object.
 	 */
 	protected function prepare_actions_for_output( $model ) {
 		$actions = [];
@@ -90,7 +89,7 @@ abstract class List_Table extends WP_List_Table {
 	/**
 	 * Get all columns to display in the list table.
 	 *
-	 * Derived from 
+	 * Derived from
 	 */
 	public function get_columns() {
 		$schema = static::get_item_schema();

--- a/inc/admin/class-withactions.php
+++ b/inc/admin/class-withactions.php
@@ -2,8 +2,6 @@
 
 namespace Foundry\Admin;
 
-use Foundry\Database\Model;
-
 trait WithActions {
 	/**
 	 * Get the actions for the model.
@@ -59,7 +57,7 @@ trait WithActions {
 	 * use PHP's `use` resolution, or call
 	 * `prepare_automatic_actions_for_output()` directly.
 	 *
-	 * @param Model $model
+	 * @param \Foundry\Database\Model $model
 	 * @return array
 	 */
 	protected function prepare_actions_for_output( $model ) {

--- a/inc/api/class-controller.php
+++ b/inc/api/class-controller.php
@@ -3,7 +3,6 @@
 namespace Foundry\Api;
 
 use Foundry\Database\Model;
-use Foundry\Database\QueryResults;
 use WP_Error;
 use WP_Http;
 use WP_REST_Controller;
@@ -93,9 +92,9 @@ abstract class Controller extends WP_REST_Controller {
 	 * @return array Route specification, used in {@see register_routes}
 	 */
 	protected function get_routes() {
-		$get_item_args = array(
+		$get_item_args = [
 			'context' => $this->get_context_param( [ 'default' => 'view' ] ),
-		);
+		];
 
 		return [
 			$this->rest_base => [
@@ -114,12 +113,12 @@ abstract class Controller extends WP_REST_Controller {
 				'schema' => [ $this, 'get_public_item_schema' ],
 			],
 			$this->rest_base . '/(?P<id>\d+)' => [
-				'args' => array(
-					'id' => array(
+				'args' => [
+					'id' => [
 						'description' => __( 'Unique identifier for the object.' ),
 						'type'        => 'integer',
-					),
-				),
+					],
+				],
 				[
 					'methods' => WP_REST_Server::READABLE,
 					'callback' => [ $this, 'get_item' ],
@@ -137,8 +136,8 @@ abstract class Controller extends WP_REST_Controller {
 					'callback' => [ $this, 'delete_item' ],
 					'permission_callback' => [ $this, 'delete_item_permissions_check' ],
 				],
-				'schema' => array( $this, 'get_public_item_schema' ),
-			]
+				'schema' => [ $this, 'get_public_item_schema' ],
+			],
 		];
 	}
 
@@ -272,7 +271,7 @@ abstract class Controller extends WP_REST_Controller {
 	 */
 	public function create_item( $request ) {
 		if ( ! empty( $request['id'] ) ) {
-			return new WP_Error( 'foundry.api.cannot_create_existing', 'Cannot create existing item.', array( 'status' => 400 ) );
+			return new WP_Error( 'foundry.api.cannot_create_existing', 'Cannot create existing item.', [ 'status' => 400 ] );
 		}
 
 		$model = $this->get_model();
@@ -282,7 +281,7 @@ abstract class Controller extends WP_REST_Controller {
 		}
 
 		if ( ! $item->is_new() ) {
-			return new WP_Error( 'foundry.api.cannot_create_existing', 'Cannot create existing item.', array( 'status' => 400 ) );
+			return new WP_Error( 'foundry.api.cannot_create_existing', 'Cannot create existing item.', [ 'status' => 400 ] );
 		}
 
 		$result = $item->save();

--- a/inc/cli/class-command.php
+++ b/inc/cli/class-command.php
@@ -4,7 +4,6 @@ namespace Foundry\Cli;
 
 use Foundry\Database\Model;
 use WP_CLI;
-use WP_CLI\Formatter;
 use WP_CLI\Iterators\Transform;
 use WP_Error;
 
@@ -86,6 +85,7 @@ abstract class Command {
 		if ( ! empty( $required ) ) {
 			WP_CLI::error(
 				sprintf(
+					/* translators: %s: Comma-separated list of missing argument names. */
 					__( 'Missing args(s): %s' ),
 					implode( ', ', $required )
 				)

--- a/inc/cli/namespace.php
+++ b/inc/cli/namespace.php
@@ -51,7 +51,7 @@ function open_file_or_stdin( $arg ) {
 	} else {
 		$readfile = 'php://stdin';
 	}
-	return fopen( $readfile, 'r' );
+	return fopen( $readfile, 'r' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
 }
 
 function parse_assoc_arg( $value, $schema, $param ) {

--- a/inc/database/class-model.php
+++ b/inc/database/class-model.php
@@ -295,8 +295,12 @@ abstract class Model {
 		$schema = static::get_table_schema();
 		$primary = get_primary_column( $schema );
 
-		$query = "SELECT * FROM `$table` WHERE `$primary` = %d LIMIT 1";
-		$prepared = $wpdb->prepare( $query, $id );
-		return $wpdb->get_row( $prepared, ARRAY_A );
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM `' . esc_sql( $table ) . '` WHERE `' . esc_sql( $primary ) . '` = %d LIMIT 1',
+				$id
+			),
+			ARRAY_A
+		);
 	}
 }

--- a/inc/database/class-query.php
+++ b/inc/database/class-query.php
@@ -194,7 +194,10 @@ class Query {
 		$where = [];
 		$where_values = [];
 
-		$where_item = is_array( $clause ) ? $clause : [ 'compare' => '=', 'value' => $clause ];
+		$where_item = is_array( $clause ) ? $clause : [
+			'compare' => '=',
+			'value'   => $clause,
+		];
 
 		// Use WP_Date_Query for date columns.
 		if ( $fields[ $field ] === 'date' ) {
@@ -305,7 +308,7 @@ class Query {
 			$where_values
 		);
 
-		$prepared = empty( $values ) ? $query : $wpdb->prepare( $query, $values );
+		$prepared = empty( $values ) ? $query : $wpdb->prepare( $query, $values ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		if ( ! $prepared ) {
 			return new WP_Error( 'prepare-failed', 'Preparing values failed.' );
 		}
@@ -325,14 +328,14 @@ class Query {
 			return $query;
 		}
 		/** @var list<object> */
-		$results = $wpdb->get_results( $query );
+		$results = $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$this->executed = true;
 
 		if ( $wpdb->last_error ) {
 			return new WP_Error( 'foundry.database.query.could_not_execute', $wpdb->last_error );
 		}
 
-		$total = (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' );
+		$total = (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		return new QueryResults( $this->config, $results, $total );
 	}
 }

--- a/inc/database/class-queryresults.php
+++ b/inc/database/class-queryresults.php
@@ -2,8 +2,8 @@
 
 namespace Foundry\Database;
 
-use Countable;
 use ArrayAccess;
+use Countable;
 use Iterator;
 
 class QueryResults implements ArrayAccess, Countable, Iterator {

--- a/inc/database/class-relationalquery.php
+++ b/inc/database/class-relationalquery.php
@@ -72,7 +72,7 @@ class RelationalQuery extends Query {
 			$join_where_values
 		);
 
-		$prepared = empty( $values ) ? $query : $wpdb->prepare( $query, $values );
+		$prepared = empty( $values ) ? $query : $wpdb->prepare( $query, $values ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		if ( ! $prepared ) {
 			return new WP_Error( 'prepare-failed', 'Preparing values failed.' );
 		}

--- a/inc/database/namespace.php
+++ b/inc/database/namespace.php
@@ -171,16 +171,16 @@ function parse_index( string $index ) : ?array {
 		. ')'
 		. '\s+'                         // Followed by at least one white space character.
 		. '(?:'                         // Name of the index. Optional if type is PRIMARY KEY.
-		. '`?'                      // Name can be escaped with a backtick.
-		. '(?P<index_name>'     // 2) Name of the index.
+		. '`?'                          // Name can be escaped with a backtick.
+		. '(?P<index_name>'             // 2) Name of the index.
 		. '(?:[0-9a-zA-Z$_-]|[\xC2-\xDF][\x80-\xBF])+'
 		. ')'
-		. '`?'                      // Name can be escaped with a backtick.
-		. '\s+'                     // Followed by at least one white space character.
+		. '`?'                          // Name can be escaped with a backtick.
+		. '\s+'                         // Followed by at least one white space character.
 		. ')*'
 		. '\('                          // Opening bracket for the columns.
 		. '(?P<index_columns>'
-		. '.+?'                 // 3) Column names, index prefixes, and orders.
+		. '.+?'                         // 3) Column names, index prefixes, and orders.
 		. ')'
 		. '\)'                          // Closing bracket for the columns.
 		. '$/im',

--- a/inc/database/namespace.php
+++ b/inc/database/namespace.php
@@ -58,7 +58,7 @@ function create_table( string $name, array $schema ) {
 	);
 
 	$prev = $wpdb->suppress_errors();
-	$result = $wpdb->query( $statement );
+	$result = $wpdb->query( $statement ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	$wpdb->suppress_errors( $prev );
 
 	if ( $result === true ) {
@@ -87,9 +87,9 @@ function conform_table( string $name, array $schema ) {
 
 	// Find any missing columns.
 	$missing_fields = $schema['fields'];
-	$existing_fields = $wpdb->get_results( sprintf( 'DESCRIBE %s;', $name ) );
+	$existing_fields = $wpdb->get_results( 'DESCRIBE `' . esc_sql( $name ) . '`;', ARRAY_A );
 	foreach ( $existing_fields as $row ) {
-		$key = $row->Field;
+		$key = $row['Field'];
 		unset( $missing_fields[ $key ] );
 	}
 
@@ -110,10 +110,10 @@ function conform_table( string $name, array $schema ) {
 		$missing_indexes[ $parsed['name'] ] = $index;
 	}
 
-	$existing_indexes = $wpdb->get_results( sprintf( 'SHOW INDEX FROM %s;', $name ) );
+	$existing_indexes = $wpdb->get_results( 'SHOW INDEX FROM `' . esc_sql( $name ) . '`;', ARRAY_A );
 
 	foreach ( $existing_indexes as $index ) {
-		$key = $index->Key_name;
+		$key = $index['Key_name'];
 		unset( $missing_indexes[ $key ] );
 	}
 
@@ -144,7 +144,7 @@ function conform_table( string $name, array $schema ) {
 	);
 
 	$prev = $wpdb->suppress_errors();
-	$result = $wpdb->query( $statement );
+	$result = $wpdb->query( $statement ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	$wpdb->suppress_errors( $prev );
 
 	if ( $result === true ) {
@@ -166,23 +166,23 @@ function parse_index( string $index ) : ?array {
 
 	$res = preg_match(
 		'/^'
-		.   '(?P<index_type>'             // 1) Type of the index.
-		.       'PRIMARY\s+KEY|(?:UNIQUE|FULLTEXT|SPATIAL)\s+(?:KEY|INDEX)|KEY|INDEX'
-		.   ')'
-		.   '\s+'                         // Followed by at least one white space character.
-		.   '(?:'                         // Name of the index. Optional if type is PRIMARY KEY.
-		.       '`?'                      // Name can be escaped with a backtick.
-		.           '(?P<index_name>'     // 2) Name of the index.
-		.               '(?:[0-9a-zA-Z$_-]|[\xC2-\xDF][\x80-\xBF])+'
-		.           ')'
-		.       '`?'                      // Name can be escaped with a backtick.
-		.       '\s+'                     // Followed by at least one white space character.
-		.   ')*'
-		.   '\('                          // Opening bracket for the columns.
-		.       '(?P<index_columns>'
-		.           '.+?'                 // 3) Column names, index prefixes, and orders.
-		.       ')'
-		.   '\)'                          // Closing bracket for the columns.
+		. '(?P<index_type>'             // 1) Type of the index.
+		. 'PRIMARY\s+KEY|(?:UNIQUE|FULLTEXT|SPATIAL)\s+(?:KEY|INDEX)|KEY|INDEX'
+		. ')'
+		. '\s+'                         // Followed by at least one white space character.
+		. '(?:'                         // Name of the index. Optional if type is PRIMARY KEY.
+		. '`?'                      // Name can be escaped with a backtick.
+		. '(?P<index_name>'     // 2) Name of the index.
+		. '(?:[0-9a-zA-Z$_-]|[\xC2-\xDF][\x80-\xBF])+'
+		. ')'
+		. '`?'                      // Name can be escaped with a backtick.
+		. '\s+'                     // Followed by at least one white space character.
+		. ')*'
+		. '\('                          // Opening bracket for the columns.
+		. '(?P<index_columns>'
+		. '.+?'                 // 3) Column names, index prefixes, and orders.
+		. ')'
+		. '\)'                          // Closing bracket for the columns.
 		. '$/im',
 		$trimmed,
 		$parts
@@ -210,7 +210,7 @@ function parse_index( string $index ) : ?array {
 	return [
 		'type' => $type,
 		'name' => $name,
-		'columns' => $parts['index_columns']
+		'columns' => $parts['index_columns'],
 	];
 }
 

--- a/inc/database/relations/class-manytomany.php
+++ b/inc/database/relations/class-manytomany.php
@@ -19,7 +19,7 @@ trait ManyToMany {
 
 		$table = $this->get_relationship_table_name();
 		return $wpdb->get_col( $wpdb->prepare(
-			"SELECT `left_id` FROM `$table` WHERE relationship = %s AND right_id = %d",
+			'SELECT `left_id` FROM `' . esc_sql( $table ) . '` WHERE relationship = %s AND right_id = %d',
 			$this->get_relationship_id(),
 			$right->get_id()
 		) );
@@ -41,7 +41,7 @@ trait ManyToMany {
 
 		$table = $this->get_relationship_table_name();
 		return $wpdb->get_col( $wpdb->prepare(
-			"SELECT `right_id` FROM `$table` WHERE relationship = %s AND left_id = %d",
+			'SELECT `right_id` FROM `' . esc_sql( $table ) . '` WHERE relationship = %s AND left_id = %d',
 			$this->get_relationship_id(),
 			$left->get_id()
 		) );
@@ -83,7 +83,7 @@ trait ManyToMany {
 			[
 				'%s',
 				'%d',
-				'%d'
+				'%d',
 			]
 		);
 	}

--- a/inc/database/relations/class-withrelationships.php
+++ b/inc/database/relations/class-withrelationships.php
@@ -31,7 +31,7 @@ trait WithRelationships {
 
 		switch ( $relation['type'] ) {
 			case 'has_many':
-				$relationship = new HasManyAssociation( static::get_table_name()  . '_relationships', $this, $type, $relation['model'] );
+				$relationship = new HasManyAssociation( static::get_table_name() . '_relationships', $this, $type, $relation['model'] );
 				break;
 
 			// case 'has_one':
@@ -76,7 +76,7 @@ trait WithRelationships {
 						break;
 					}
 
-					$table_name = static::get_table_name()  . '_relationships';
+					$table_name = static::get_table_name() . '_relationships';
 					$schema = [
 						'fields' => [
 							'relationship' => 'varchar(255) NOT NULL',


### PR DESCRIPTION
- Fixes the below PHPCS errors which pop-up when using Foundry as a submodule in Vantage

https://github.com/humanmade/foundry/commit/4750dbe1922633ca33844d9d353258cc10ad70c8

```
FILE: ./inc/database/class-query.php
---------------------------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
---------------------------------------------------------------------------------------------------------------------
 196 | ERROR | [x] When a multi-item array uses associative keys, each value should start on a new line.
 270 | ERROR | [ ] Use placeholders and $wpdb->prepare(); found $query
 290 | ERROR | [ ] Use placeholders and $wpdb->prepare(); found $query
---------------------------------------------------------------------------------------------------------------------
```

https://github.com/humanmade/foundry/commit/0908f2dd02a203f0b5b3d002322fda0a516972bc

```
FILE: ./inc/database/relations/class-withrelationships.php
--------------------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------------------------------
 34 | ERROR | [x] Concat operator must be surrounded by a single space
 79 | ERROR | [x] Concat operator must be surrounded by a single space
--------------------------------------------------------------------------------------------------------
```

https://github.com/humanmade/foundry/commit/441c2473c6d58efc807127edfd214d070de10219

```
FILE: ./inc/database/relations/class-manytomany.php
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 22 | ERROR | [ ] Use placeholders and $wpdb->prepare(); found interpolated variable $table at "SELECT `left_id` FROM `$table` WHERE relationship = %s AND right_id = %d"
 44 | ERROR | [ ] Use placeholders and $wpdb->prepare(); found interpolated variable $table at "SELECT `right_id` FROM `$table` WHERE relationship = %s AND left_id = %d"
 86 | ERROR | [x] Each array item in a multi-line array declaration must end in a comma
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

https://github.com/humanmade/foundry/commit/89d216c93a2deb9dfdfdd94e7567792fdbc1e509

```

FILE: ./inc/database/class-relationalquery.php
--------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------------------
 75 | ERROR | Use placeholders and $wpdb->prepare(); found $query
--------------------------------------------------------------------------------------------
```

https://github.com/humanmade/foundry/commit/5f7fa12a2770e6b14c90c2553245c10e9d68d9ea

```
FILE: ./inc/database/class-queryresults.php
-----------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------------------
 5 | ERROR | [x] Use classes must be in alphabetical order.
-----------------------------------------------------------------------------------------
```

https://github.com/humanmade/foundry/commit/36c50cef270ae72246317e416b2e4ec5c5b11825

```
FILE: ./inc/database/class-model.php
----------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------------------
 299 | ERROR | Use placeholders and $wpdb->prepare(); found $query
 300 | ERROR | Use placeholders and $wpdb->prepare(); found $prepared
----------------------------------------------------------------------------------
```

https://github.com/humanmade/foundry/commit/282162152080597e9df9fc0bd1cc36f252785894

```
FILE: .inc/database/namespace.php
-----------------------------------------------------------------------------------------
FOUND 24 ERRORS AFFECTING 24 LINES
-----------------------------------------------------------------------------------------
  61 | ERROR | [ ] Use placeholders and $wpdb->prepare(); found $statement
  90 | ERROR | [ ] Use placeholders and $wpdb->prepare(); found $name
  92 | ERROR | [ ] Object property "Field" is not in valid snake_case format
 113 | ERROR | [ ] Use placeholders and $wpdb->prepare(); found $name
 116 | ERROR | [ ] Object property "Key_name" is not in valid snake_case format
 147 | ERROR | [ ] Use placeholders and $wpdb->prepare(); found $statement
 169 | ERROR | [x] Concat operator must be surrounded by a single space
 170 | ERROR | [x] Concat operator must be surrounded by a single space
 171 | ERROR | [x] Concat operator must be surrounded by a single space
 172 | ERROR | [x] Concat operator must be surrounded by a single space
 173 | ERROR | [x] Concat operator must be surrounded by a single space
 174 | ERROR | [x] Concat operator must be surrounded by a single space
 175 | ERROR | [x] Concat operator must be surrounded by a single space
 176 | ERROR | [x] Concat operator must be surrounded by a single space
 177 | ERROR | [x] Concat operator must be surrounded by a single space
 178 | ERROR | [x] Concat operator must be surrounded by a single space
 179 | ERROR | [x] Concat operator must be surrounded by a single space
 180 | ERROR | [x] Concat operator must be surrounded by a single space
 181 | ERROR | [x] Concat operator must be surrounded by a single space
 182 | ERROR | [x] Concat operator must be surrounded by a single space
 183 | ERROR | [x] Concat operator must be surrounded by a single space
 184 | ERROR | [x] Concat operator must be surrounded by a single space
 185 | ERROR | [x] Concat operator must be surrounded by a single space
 213 | ERROR | [x] Each array item in a multi-line array declaration must end in a comma
-----------------------------------------------------------------------------------------
```

https://github.com/humanmade/foundry/commit/f65417f49eddd393bf083580e4dfa8e74e850e89

```
FILE: ./inc/admin/class-list-table.php
------------------------------------------------------------------------------------
FOUND 1 ERROR AND 1 WARNING AFFECTING 2 LINES
------------------------------------------------------------------------------------
  5 | WARNING | [x] Unused use statement
 93 | ERROR   | [x] Whitespace found at end of line
------------------------------------------------------------------------------------
```

https://github.com/humanmade/foundry/commit/769ee015cbe846234eb89607cd9535ae2700c0ce

```
FILE: ./inc/admin/class-withactions.php
-------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-------------------------------------------------------------------------------------
 5 | WARNING | [x] Unused use statement
-------------------------------------------------------------------------------------
```

https://github.com/humanmade/foundry/commit/0d347e0c6781df2d6684544f3390c0c5a62a5eef

```
FILE: ./inc/cli/class-command.php
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  7 | WARNING | [x] Unused use statement
 89 | WARNING | [ ] A gettext call containing placeholders was found, but was not accompanied by a "translators:" comment on the line above to clarify the meaning of the
    |         |     placeholders.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

https://github.com/humanmade/foundry/commit/bc427a9a7e69ea76d5791ca6c38ee3bb2aa95ba0

```
FILE: ./inc/cli/namespace.php
------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------
 54 | WARNING | File operations should use WP_Filesystem methods instead of direct PHP filesystem calls. Found: fopen()
```

https://github.com/humanmade/foundry/commit/65c714eb20fb64f5229298324fe0e409968a5551

```

FILE: ./inc/api/class-controller.php
-------------------------------------------------------------------------------------------
FOUND 7 ERRORS AND 1 WARNING AFFECTING 8 LINES
-------------------------------------------------------------------------------------------
   6 | WARNING | [x] Unused use statement
  96 | ERROR   | [x] Short array syntax must be used to define arrays
 117 | ERROR   | [x] Short array syntax must be used to define arrays
 118 | ERROR   | [x] Short array syntax must be used to define arrays
 140 | ERROR   | [x] Short array syntax must be used to define arrays
 141 | ERROR   | [x] Each array item in a multi-line array declaration must end in a comma
 275 | ERROR   | [x] Short array syntax must be used to define arrays
 285 | ERROR   | [x] Short array syntax must be used to define arrays
-------------------------------------------------------------------------------------------
```